### PR TITLE
Fix duplicate SW logic in mini.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@
 - [ ] *example* Create meta descriptions for the new “Base‑64 Encoder” page (assigned → **OminiSEO**).
 - [x] Clean up `README.md` and document build steps (assigned → **OminiDoc**) (removed stray JS and clarified build script).
 - [x] Deduplicate fonts/scripts and footers in `index.html`, add manifest link (assigned → **OminiUI**). (cleaned head & footer)
-- [ ] Refactor `mini.js` to remove duplicate service-worker logic (assigned → **OminiLogic**).
+- [x] Refactor `mini.js` to remove duplicate service-worker logic (assigned → **OminiLogic**). (deduplicated SW and AOS init)
 - [ ] Populate icons in `manifest.webmanifest` and ensure canonical tags across pages (assigned → **OminiSEO**).
 - [ ] Add `esbuild` and `workbox-cli` dev dependencies (assigned → **OminiReq**).
 - [ ] Verify internal links using **LinkCheckAgent** (spawned via OminiForge).

--- a/mini.js
+++ b/mini.js
@@ -1,81 +1,56 @@
-// Alpine stores for theme and search
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js');
-}
-
-// Init Alpine stores
-document.addEventListener('alpine:init', () => {
-  Alpine.store('theme', {
-    mode: localStorage.getItem('theme') || 'dark',
-    init() { this.apply(); },
-    toggle() { this.mode = this.mode === 'dark' ? 'cupcake' : 'dark'; this.apply(); },
-    apply() { document.documentElement.setAttribute('data-theme', this.mode); localStorage.setItem('theme', this.mode); }
-  });
-  Alpine.store('search', { query: '' });
-});
-
-// DOM ready scripts
-document.addEventListener('DOMContentLoaded', () => {
-  // AOS fade-up
-  if (window.AOS) AOS.init({ once: true });
-
-  // GSAP parallax stars
-  if (window.gsap) {
-    gsap.to('#stars', { backgroundPosition: '0 200%', duration: 40, ease: 'none', repeat: -1 });
-    gsap.utils.toArray('section').forEach(sec => {
-      ScrollTrigger.create({ trigger: sec, start: 'top 80%', onEnter: () => gsap.to(sec, { opacity: 1, y: 0, duration: 0.5 }), once: true, scrub: true });
-    });
-  }
-
-  // Fade transition
-  document.querySelectorAll('a[href$=".html"]').forEach(a => {
-    a.addEventListener('click', e => {
-      if (e.ctrlKey || e.metaKey) return;
-      e.preventDefault();
-      gsap.to('body', { opacity: 0, duration: 0.4, onComplete: () => { window.location = a.href; } });
-    });
-  });
-});
-
-// Plausible custom event helper
-function trackRun(tool) {
-  if (window.plausible) plausible('tool_run', { props: { tool } });
-}
-// Expose decorate function for tool pages
-function decorateToolPage() {}
+// Alpine stores for theme and search and service worker
 function filesToCache(){
   const links=['./','style.min.css','dark.min.css','mini.js','app.min.js','tools.css'];
-  const links=[ './','tools.css','mini.js'];
   document.querySelectorAll('a[href$=".html"]').forEach(a=>links.push(a.getAttribute('href')));
   return links;
+}
+
 if('serviceWorker' in navigator){
   const files=filesToCache();
   const sw=`const C='mtu-v2';self.addEventListener('install',e=>e.waitUntil(caches.open(C).then(c=>c.addAll(${JSON.stringify(files)}))));self.addEventListener('fetch',e=>e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request))));`;
-  const sw=`const C='mtu-v2';self.addEventListener('install',e=>e.waitUntil(caches.open(C).then(c=>c.addAll(${JSON.stringify(['./','tools.css','mini.js'])})))) ;self.addEventListener('fetch',e=>e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request))));`;
   navigator.serviceWorker.register(URL.createObjectURL(new Blob([sw],{type:'text/javascript'})));
+}
+
 document.addEventListener('alpine:init',()=>{
   Alpine.store('theme',{
     mode:localStorage.getItem('theme')||'dark',
     init(){this.apply();},
     toggle(){this.mode=this.mode==='dark'?'light':'dark';this.apply();},
     apply(){document.documentElement.classList.toggle('light',this.mode==='light');localStorage.setItem('theme',this.mode);}
+  });
   Alpine.store('search',{query:''});
+});
+
 document.addEventListener('DOMContentLoaded',()=>{
-  AOS.init({once:true});
-  AOS.init();
-  gsap.to('#stars',{backgroundPosition:'0 200%',duration:40,ease:'none',repeat:-1});
+  if(window.AOS) AOS.init({once:true});
+  if(window.gsap){
+    gsap.to('#stars',{backgroundPosition:'0 200%',duration:40,ease:'none',repeat:-1});
+    gsap.utils.toArray('section').forEach(sec=>{
+      ScrollTrigger.create({trigger:sec,start:'top 80%',onEnter:()=>gsap.to(sec,{opacity:1,y:0,duration:0.5}),once:true,scrub:true});
+    });
+  }
   document.querySelectorAll('a[href$=".html"]').forEach(a=>{
     a.addEventListener('click',e=>{if(e.ctrlKey||e.metaKey)return;e.preventDefault();gsap.to('body',{opacity:0,duration:0.4,onComplete:()=>{window.location=a.href;}});});
+  });
   document.querySelectorAll('.tool-card').forEach(card=>{
     const arrow=card.querySelector('.fa-arrow-right');
     if(!arrow)return;
     card.addEventListener('mouseenter',()=>gsap.to(arrow,{x:6,opacity:1,duration:0.3}));
     card.addEventListener('mouseleave',()=>gsap.to(arrow,{x:0,opacity:0,duration:0.3}));
+  });
   document.querySelectorAll('.copy-btn').forEach(btn=>{
     btn.classList.add('btn','btn-primary','mt-2');
+  });
   document.querySelectorAll('main > div:first-of-type').forEach(el=>{
     el.classList.add('card','p-4','shadow','mt-4','animate__animated','animate__zoomIn');
     el.setAttribute('data-aos','zoom-in');
-function decorateToolPage(){
-  // placeholder to inject shared nav/footer in future
+  });
+});
 
+// Plausible custom event helper
+function trackRun(tool){
+  if(window.plausible) plausible('tool_run',{props:{tool}});
+}
+
+// Expose decorate function for tool pages
+function decorateToolPage(){}


### PR DESCRIPTION
## Summary
- remove leftover fragments in `mini.js`
- keep a single `filesToCache` helper and service worker registration
- call Alpine store setup and AOS init only once
- mark mini.js cleanup task done

## Testing
- `npm run lint` *(fails: HTMLHint errors)*
- `npm run lint:js` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e7174ad688321b9be32ce94000903