### PR TITLE
Update meta tags for Base64 Encoder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@
 ## Task List
 
 ### 🔄 Active
-- [ ] *example* Create meta descriptions for the new “Base‑64 Encoder” page (assigned → **OminiSEO**).
+- [x] *example* Create meta descriptions for the new “Base‑64 Encoder” page (assigned → **OminiSEO**) (added meta description and og tags).
 - [x] Clean up `README.md` and document build steps (assigned → **OminiDoc**) (removed stray JS and clarified build script).
 - [x] Deduplicate fonts/scripts and footers in `index.html`, add manifest link (assigned → **OminiUI**). (cleaned head & footer)
 - [x] Refactor `mini.js` to remove duplicate service-worker logic (assigned → **OminiLogic**). (deduplicated SW and AOS init)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The repository includes prebuilt `style.min.css` and `app.min.js`, so you can si
 | Paint Coverage Calculator | Paint Coverage Calculator - Estimate Gallons Needed | Paint Coverage Calculator shows how many gallons you need for any room or project. |
 | Color Converter | Color Converter - HEX to RGB and HSL | Color Converter translates HEX color codes to RGB and HSL values instantly. |
 | Fuel Cost Calculator | Fuel Cost Calculator - Estimate Trip Fuel Expense | Fuel Cost Calculator computes fuel costs from distance, price and MPG. |
-| Base64 Encoder/Decoder | Base64 Encoder/Decoder - Convert Text Quickly | Base64 Encoder/Decoder transforms text to base64 and back instantly in your browser. |
+| Base64 Encoder/Decoder | Base64 Encoder/Decoder - Convert Text Quickly | Base64 Encoder/Decoder converts text to and from base64 instantly. Offline, secure and free. |
 | Body Fat Calculator | Body Fat Calculator - Estimate Percentage Quickly | Body Fat Calculator estimates body fat from simple measurements. |
 | Pomodoro Timer | Pomodoro Timer - Boost Focus in 25-Minute Sessions | Pomodoro Timer now includes pause and reset options for flexible sessions. |
 | Color Picker | Color Picker - Copy HEX, RGB and HSL | Color Picker displays color codes instantly so designers can copy them. |

--- a/tools/base64-encoder/index.html
+++ b/tools/base64-encoder/index.html
@@ -4,11 +4,11 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Base64 Encoder/Decoder - Convert Text Quickly</title>
-<meta name="description" content="Base64 Encoder/Decoder transforms text to base64 and back instantly in your browser." />
+<meta name="description" content="Base64 Encoder/Decoder converts text to and from base64 instantly. Offline, secure and free." />
 <meta name="robots" content="index,follow">
 <meta property="og:url" content="https://example.com/tools/base64-encoder/">
 <meta property="og:title" content="Base64 Encoder/Decoder"/>
-<meta property="og:description" content="Encode or decode base64 strings"/>
+<meta property="og:description" content="Convert text to and from base64 instantly. Works offline with no data sent to servers."/>
 <link rel="canonical" href="https://example.com/tools/base64-encoder/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- improve Base64 Encoder page SEO description and OG tags
- sync README keyword table
- mark task complete in AGENTS list

## Testing
- `npm run lint` *(fails: 15 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684e9d1324d08321b39d6115c6d600c0