### PR TITLE
Add OpenMoji previews and HTML validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install Python deps
+        run: pip install -r requirements.txt
+
       - name: Install dependencies
         run: npm ci
 
@@ -31,6 +34,9 @@ jobs:
 
       - name: Build project
         run: npm run build
+
+      - name: Validate HTML
+        run: html5validator --config .html5validator.yml index.html tools/*/index.html
 
       - name: Accessibility check (Pa11y)
         run: |

--- a/.html5validator.yml
+++ b/.html5validator.yml
@@ -1,0 +1,8 @@
+root: .
+blacklist:
+  - node_modules
+  - dist
+ignore_re:
+  - 'Attribute "x-[^" ]*" not allowed'
+  - 'Attribute ":[^" ]*" not allowed'
+  - 'Attribute "@[^" ]*" not allowed'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,10 @@
 ## Task List
 
 ### 🔄 Active
-- [ ] Remove duplicate Google Fonts link and add an aria-label to the color input in `tools/color-picker/index.html` (assigned → **OminiUI**)
-- [ ] Add `og:image` meta tags referencing OpenMoji icons for index and tool pages, then update `sitemap.xml` if needed (assigned → **OminiSEO**)
-- [ ] Document offline caching and the Dexie database in `README.md` (assigned → **OminiDoc**)
-- [ ] Configure `html5validator` to allow custom `x-*` attributes and integrate it into the CI workflow (assigned → **OminiReq**)
+- [x] Remove duplicate Google Fonts link and add an aria-label to the color input in `tools/color-picker/index.html` (assigned → **OminiUI**)
+- [x] Add `og:image` meta tags referencing OpenMoji icons for index and tool pages, then update `sitemap.xml` if needed (assigned → **OminiSEO**)
+- [x] Document offline caching and the Dexie database in `README.md` (assigned → **OminiDoc**)
+- [x] Configure `html5validator` to allow custom `x-*` attributes and integrate it into the CI workflow (assigned → **OminiReq**)
 
 
 ### ✅ Completed

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This is a simplified demo of the MiniTools Universe static website. It provides 
 ## Build instructions
 The repository includes prebuilt `style.min.css` and `app.min.js`, so you can simply open `index.html` without any compilation. If you modify the CSS or JavaScript sources, run `node build.js` to regenerate the minified assets and refresh the service worker cache.
 
+## Offline caching and database
+The site uses a Workbox service worker (`sw.js`) to precache assets and keep pages available offline. Runtime caching covers fonts, scripts and images so tools load instantly on repeat visits. Recent tool results are stored with Dexie.js (`db.js`) in an `mtu` IndexedDB database for offline retrieval.
+
 ## Omini agents
 This project uses a set of "Omini agents" defined in `AGENTS.md` to keep docs, UI, SEO and code in sync.
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 <meta property="og:description" content="Explore calculators, converters and utilities in a single hub.">
 <meta property="og:url" content="https://example.com/index.html">
 <link rel="canonical" href="https://example.com/index.html">
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F527.png">
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/age-calculator/index.html
+++ b/tools/age-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/age-calculator/">
 <meta property="og:title" content="Age Calculator"/>
 <meta property="og:description" content="Find your exact age in years"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F382.png"/>
 <link rel="canonical" href="https://example.com/tools/age-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/base64-encoder/index.html
+++ b/tools/base64-encoder/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/base64-encoder/">
 <meta property="og:title" content="Base64 Encoder/Decoder"/>
 <meta property="og:description" content="Convert text to and from base64 instantly. Works offline with no data sent to servers."/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F524.png"/>
 <link rel="canonical" href="https://example.com/tools/base64-encoder/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/basic-calculator/index.html
+++ b/tools/basic-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/basic-calculator/">
 <meta property="og:title" content="Basic Calculator"/>
 <meta property="og:description" content="Quick online arithmetic"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F9EE.png"/>
 <link rel="canonical" href="https://example.com/tools/basic-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/bmi-calculator/index.html
+++ b/tools/bmi-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/bmi-calculator/">
 <meta property="og:title" content="BMI Calculator"/>
 <meta property="og:description" content="Check your body mass index"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/2696-FE0F.png"/>
 <link rel="canonical" href="https://example.com/tools/bmi-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/bmr-calculator/index.html
+++ b/tools/bmr-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/bmr-calculator/">
 <meta property="og:title" content="BMR Calculator"/>
 <meta property="og:description" content="Estimate daily calorie needs"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F525.png"/>
 <link rel="canonical" href="https://example.com/tools/bmr-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/body-fat-calculator/index.html
+++ b/tools/body-fat-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/body-fat-calculator/">
 <meta property="og:title" content="Body Fat Calculator"/>
 <meta property="og:description" content="Estimate body fat percentage"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4AA.png"/>
 <link rel="canonical" href="https://example.com/tools/body-fat-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/car-loan-calculator/index.html
+++ b/tools/car-loan-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/car-loan-calculator/">
 <meta property="og:title" content="Car Loan Calculator"/>
 <meta property="og:description" content="Estimate monthly mortgage or loan costs"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3E6.png"/>
 <link rel="canonical" href="https://example.com/tools/car-loan-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/circle-area-calculator/index.html
+++ b/tools/circle-area-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/circle-area-calculator/">
 <meta property="og:title" content="Circle Area Calculator"/>
 <meta property="og:description" content="Find disk size from radius or diameter"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/2B55.png"/>
 <link rel="canonical" href="https://example.com/tools/circle-area-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/color-converter/index.html
+++ b/tools/color-converter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/color-converter/">
 <meta property="og:title" content="Color Converter"/>
 <meta property="og:description" content="Convert hex colors to RGB or HSL"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3A8.png"/>
 <link rel="canonical" href="https://example.com/tools/color-converter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/color-picker/index.html
+++ b/tools/color-picker/index.html
@@ -9,10 +9,10 @@
 <meta property="og:url" content="https://example.com/tools/color-picker/">
 <meta property="og:title" content="Color Picker"/>
 <meta property="og:description" content="Pick colors and copy codes instantly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3A8.png"/>
 <link rel="canonical" href="https://example.com/tools/color-picker/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&amp;display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-TNPe8tkCbZ2M1zDh/QEqplLWYwgdEN0OZK0s8AjtKoa6HgMHtYjgJv1bLvK+cvM/" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
@@ -30,7 +30,7 @@
 <main data-aos="fade-in" class="container animate__animated animate__fadeIn">
 <p><strong>Color Picker</strong> lets designers quickly choose any hue and instantly see its HEX, RGB and HSL codes. Use the slider or enter a value to refine your shade, then copy the color codes to your clipboard with one click. The entire tool works offline after the first visit so you can rely on it anywhere. Simple and fast, it&rsquo;s perfect for web projects, graphic design or presentations. Try the Color Picker now!</p>
 <div>
-<input type="color" id="picker" value="#3f51b5">
+<input type="color" id="picker" value="#3f51b5" aria-label="Pick a color">
 <p>HEX: <span id="hex">#3f51b5</span> <button id="copyHex">Copy</button></p>
 <p>RGB: <span id="rgb">63,81,181</span> <button id="copyRgb">Copy</button></p>
 <p>HSL: <span id="hsl">231,48%,48%</span> <button id="copyHsl">Copy</button></p>

--- a/tools/compound-interest-calculator/index.html
+++ b/tools/compound-interest-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/compound-interest-calculator/">
 <meta property="og:title" content="Compound Interest Calculator"/>
 <meta property="og:description" content="See savings grow with compound interest"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4B9.png"/>
 <link rel="canonical" href="https://example.com/tools/compound-interest-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/countdown-timer/index.html
+++ b/tools/countdown-timer/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/countdown-timer/">
 <meta property="og:title" content="Countdown Timer"/>
 <meta property="og:description" content="Set a timer and count down easily"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/23F3.png"/>
 <link rel="canonical" href="https://example.com/tools/countdown-timer/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/csv-to-json/index.html
+++ b/tools/csv-to-json/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/csv-to-json/">
 <meta property="og:title" content="CSV to JSON Converter"/>
 <meta property="og:description" content="Convert CSV files to JSON instantly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4D1.png"/>
 <link rel="canonical" href="https://example.com/tools/csv-to-json/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/currency-converter/index.html
+++ b/tools/currency-converter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/currency-converter/">
 <meta property="og:title" content="Currency Converter"/>
 <meta property="og:description" content="Convert between USD, EUR and GBP"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4B1.png"/>
 <link rel="canonical" href="https://example.com/tools/currency-converter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/date-difference-calculator/index.html
+++ b/tools/date-difference-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/date-difference-calculator/">
 <meta property="og:title" content="Date Difference Calculator"/>
 <meta property="og:description" content="Measure the days between any two dates"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4C6.png"/>
 <link rel="canonical" href="https://example.com/tools/date-difference-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/dice-roller/index.html
+++ b/tools/dice-roller/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/dice-roller/">
 <meta property="og:title" content="Dice Roller"/>
 <meta property="og:description" content="Roll dice with animation and copy results"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3B2.png"/>
 <link rel="canonical" href="https://example.com/tools/dice-roller/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/discount-calculator/index.html
+++ b/tools/discount-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/discount-calculator/">
 <meta property="og:title" content="Discount Calculator"/>
 <meta property="og:description" content="Calculate sale prices and savings"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3F7-FE0F.png"/>
 <link rel="canonical" href="https://example.com/tools/discount-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/epoch-time-converter/index.html
+++ b/tools/epoch-time-converter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/epoch-time-converter/">
 <meta property="og:title" content="Epoch Time Converter"/>
 <meta property="og:description" content="Convert dates to and from Unix time"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/23F1-FE0F.png"/>
 <link rel="canonical" href="https://example.com/tools/epoch-time-converter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/fraction-calculator/index.html
+++ b/tools/fraction-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/fraction-calculator/">
 <meta property="og:title" content="Fraction Calculator"/>
 <meta property="og:description" content="Solve fraction problems easily"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/BC.png"/>
 <link rel="canonical" href="https://example.com/tools/fraction-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/fuel-cost-calculator/index.html
+++ b/tools/fuel-cost-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/fuel-cost-calculator/">
 <meta property="og:title" content="Fuel Cost Calculator"/>
 <meta property="og:description" content="Estimate fuel expenses for road trips"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/26FD.png"/>
 <link rel="canonical" href="https://example.com/tools/fuel-cost-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/graphing-calculator/index.html
+++ b/tools/graphing-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/graphing-calculator/">
 <meta property="og:title" content="Graphing Calculator"/>
 <meta property="og:description" content="Visualize equations in your browser"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4C8.png"/>
 <link rel="canonical" href="https://example.com/tools/graphing-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/json-formatter/index.html
+++ b/tools/json-formatter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/json-formatter/">
 <meta property="og:title" content="JSON Formatter"/>
 <meta property="og:description" content="Format and validate JSON instantly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/7B-7D.png"/>
 <link rel="canonical" href="https://example.com/tools/json-formatter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/loan-calculator/index.html
+++ b/tools/loan-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/loan-calculator/">
 <meta property="og:title" content="Loan Calculator"/>
 <meta property="og:description" content="Estimate monthly mortgage or loan costs"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3E6.png"/>
 <link rel="canonical" href="https://example.com/tools/loan-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/markdown-editor/index.html
+++ b/tools/markdown-editor/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/markdown-editor/">
 <meta property="og:title" content="Markdown Editor"/>
 <meta property="og:description" content="Edit Markdown and see the result instantly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4DD.png"/>
 <link rel="canonical" href="https://example.com/tools/markdown-editor/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/paint-coverage-calculator/index.html
+++ b/tools/paint-coverage-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/paint-coverage-calculator/">
 <meta property="og:title" content="Paint Coverage Calculator"/>
 <meta property="og:description" content="Estimate paint requirements for your space"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3A8.png"/>
 <link rel="canonical" href="https://example.com/tools/paint-coverage-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/percentage-calculator/index.html
+++ b/tools/percentage-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/percentage-calculator/">
 <meta property="og:title" content="Percentage Calculator"/>
 <meta property="og:description" content="Find percent of any number"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4CA.png"/>
 <link rel="canonical" href="https://example.com/tools/percentage-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/pomodoro-timer/index.html
+++ b/tools/pomodoro-timer/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/pomodoro-timer/">
 <meta property="og:title" content="Pomodoro Timer"/>
 <meta property="og:description" content="Work in focused intervals"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F345.png"/>
 <link rel="canonical" href="https://example.com/tools/pomodoro-timer/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/random-number-generator/index.html
+++ b/tools/random-number-generator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/random-number-generator/">
 <meta property="og:title" content="Random Number Generator"/>
 <meta property="og:description" content="Pick random numbers instantly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F3B2.png"/>
 <link rel="canonical" href="https://example.com/tools/random-number-generator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/scientific-calculator/index.html
+++ b/tools/scientific-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/scientific-calculator/">
 <meta property="og:title" content="Scientific Calculator"/>
 <meta property="og:description" content="Advanced calculator for complex math"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4D0.png"/>
 <link rel="canonical" href="https://example.com/tools/scientific-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/simple-interest-calculator/index.html
+++ b/tools/simple-interest-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/simple-interest-calculator/">
 <meta property="og:title" content="Simple Interest Calculator"/>
 <meta property="og:description" content="Estimate loan interest fast"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4B0.png"/>
 <link rel="canonical" href="https://example.com/tools/simple-interest-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/stopwatch/index.html
+++ b/tools/stopwatch/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/stopwatch/">
 <meta property="og:title" content="Stopwatch"/>
 <meta property="og:description" content="Simple online stopwatch"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/23F1-FE0F.png"/>
 <link rel="canonical" href="https://example.com/tools/stopwatch/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/temperature-converter/index.html
+++ b/tools/temperature-converter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/temperature-converter/">
 <meta property="og:title" content="Temperature Converter"/>
 <meta property="og:description" content="Convert between Celsius and Fahrenheit"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F321-FE0F.png"/>
 <link rel="canonical" href="https://example.com/tools/temperature-converter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/time-zone-converter/index.html
+++ b/tools/time-zone-converter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/time-zone-converter/">
 <meta property="og:title" content="Time Zone Converter"/>
 <meta property="og:description" content="Compare times across time zones"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F551.png"/>
 <link rel="canonical" href="https://example.com/tools/time-zone-converter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/tip-calculator/index.html
+++ b/tools/tip-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/tip-calculator/">
 <meta property="og:title" content="Tip Calculator"/>
 <meta property="og:description" content="Calculate tips and split bills quickly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4B5.png"/>
 <link rel="canonical" href="https://example.com/tools/tip-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/triangle-area-calculator/index.html
+++ b/tools/triangle-area-calculator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/triangle-area-calculator/">
 <meta property="og:title" content="Triangle Area Calculator"/>
 <meta property="og:description" content="Compute triangle area from base and height"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F53A.png"/>
 <link rel="canonical" href="https://example.com/tools/triangle-area-calculator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/unit-converter/index.html
+++ b/tools/unit-converter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/unit-converter/">
 <meta property="og:title" content="Unit Converter"/>
 <meta property="og:description" content="Quickly convert metric and imperial units"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F504.png"/>
 <link rel="canonical" href="https://example.com/tools/unit-converter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/uuid-generator/index.html
+++ b/tools/uuid-generator/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/uuid-generator/">
 <meta property="og:title" content="UUID Generator"/>
 <meta property="og:description" content="Generate version 4 UUIDs instantly"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F194.png"/>
 <link rel="canonical" href="https://example.com/tools/uuid-generator/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools/word-counter/index.html
+++ b/tools/word-counter/index.html
@@ -9,6 +9,7 @@
 <meta property="og:url" content="https://example.com/tools/word-counter/">
 <meta property="og:title" content="Word Counter"/>
 <meta property="og:description" content="Free word and character counter"/>
+<meta property="og:image" content="https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/png/256x256/1F4DD.png"/>
 <link rel="canonical" href="https://example.com/tools/word-counter/" />
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add `og:image` meta tag to index and every tool page
- document offline caching and the Dexie DB
- remove duplicate font link and improve color input a11y
- configure `html5validator` and run it in CI
- mark tasks done in `AGENTS.md`

## Testing
- `npm run lint`
- `npm run build` *(fails: Specified input file src/styles/tailwind.css does not exist)*
- `html5validator --config .html5validator.yml index.html tools/color-picker/index.html`

------
https://chatgpt.com/codex/tasks/task_e_684eacfaf1908321a988a7e4c94de3d3