### PR TITLE
Fix pa11y root issue

### DIFF
--- a/pa11y.json
+++ b/pa11y.json
@@ -1,0 +1,5 @@
+{
+  "chromeLaunchConfig": {
+    "args": ["--no-sandbox"]
+  }
+}


### PR DESCRIPTION
## Summary
- add `pa11y.json` with `--no-sandbox` flag so a11y tests run as root

## Testing
- `npm run lint`
- `npm run build`
- `npx pa11y http://localhost:8080` (fails on missing lang attribute)


------
https://chatgpt.com/codex/tasks/task_e_684eb0907a3483219d0151f874a4dd68