### PR TITLE
serve workbox locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@
 - [x] Add missing `src/styles/tailwind.css` so `npm run build` succeeds (assigned → **OminiUI**) (file committed)
 - [x] Insert skip link on all pages and style in `tools.css` (assigned → **OminiUI**) (adds skip-link element and style)
 - [x] Document local vendor CDN assets and emoji/SVG image replacements in `README.md` (assigned → **OminiDoc**) (added vendor section)
+- [x] Download `workbox-sw.js` during build and load it from `/vendor/workbox/`; update `sw.js` accordingly (assigned → **OminiReq**) (build copies local library)
 
 
 ### ✅ Completed

--- a/build.js
+++ b/build.js
@@ -1,9 +1,15 @@
 /* eslint-env node */
 /* global require, process */
 const {execSync}=require('child_process');
+const fs=require('fs');
+const path=require('path');
 try{
   execSync('npx tailwindcss -m -o style.min.css');
   execSync('npx esbuild mini.js --bundle --minify --sourcemap --outfile=app.min.js');
   execSync('npx workbox-cli injectManifest');
+  const workboxSrc=path.join('node_modules','workbox-sw','build','workbox-sw.js');
+  const workboxDir=path.join('vendor','workbox');
+  fs.mkdirSync(workboxDir,{recursive:true});
+  fs.copyFileSync(workboxSrc,path.join(workboxDir,'workbox-sw.js'));
   console.log('Build complete');
 }catch(e){console.error(e.message);process.exit(1);}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input",
     "lint:html": "htmlhint \"**/*.html\"",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:html",
-    "build": "mkdir -p dist/css && npx tailwindcss -c tailwind.config.js -i src/styles/tailwind.css -o dist/css/styles.css --minify",
+    "build": "mkdir -p dist/css vendor/workbox && cp node_modules/workbox-sw/build/workbox-sw.js vendor/workbox/workbox-sw.js && npx tailwindcss -c tailwind.config.js -i src/styles/tailwind.css -o dist/css/styles.css --minify",
     "start": "http-server dist -p 8080"
   },
   "devDependencies": {

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,10 @@
 /* eslint-env serviceworker */
 /* global importScripts, workbox */
-importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+try{
+  importScripts('/vendor/workbox/workbox-sw.js');
+}catch(e){
+  importScripts('https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js');
+}
 self.skipWaiting();
 workbox.core.clientsClaim();
 workbox.precaching.precacheAndRoute(self.__WB_MANIFEST||[]);


### PR DESCRIPTION
## Summary
- copy `workbox-sw.js` from `node_modules` to `vendor/workbox` during build
- load local `workbox-sw.js` in the service worker with CDN fallback
- record completed task in `AGENTS.md`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ec03f5a908321a91d04c5debf4a31