### PR TITLE
Add external libraries guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@
 - [x] Download `workbox-sw.js` during build and load it from `/vendor/workbox/`; update `sw.js` accordingly (assigned → **OminiReq**) (build copies local library)
 - [x] Provide PowerShell script for Windows to download OpenMoji icons into `assets/` (assigned → **OminiReq**) (script added)
 
+- [x] Summarize CDN usage in `docs/external-libraries.md` and link from `README.md` (assigned → **OminiDoc**) (external libs documented)
+
 
 ### ✅ Completed
 - [x] Added `<link rel="manifest">` to all pages (OminiUI).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a simplified demo of the MiniTools Universe static website. It provides 
 The repository includes prebuilt `style.min.css` and `app.min.js`, so you can simply open `index.html` without any compilation. If you modify the CSS or JavaScript sources, run `node build.js` to regenerate the minified assets and refresh the service worker cache.
 
 ## Offline caching and database
-The site uses a Workbox service worker (`sw.js`) to precache assets and keep pages available offline. Runtime caching covers fonts, scripts and images so tools load instantly on repeat visits. Recent tool results are stored with Dexie.js (`db.js`) in an `mtu` IndexedDB database for offline retrieval.
+The site uses a Workbox service worker (`sw.js`) to precache assets and keep pages available offline. Runtime caching covers fonts, scripts and images so tools load instantly on repeat visits. Recent tool results are stored with Dexie.js (`db.js`) in an `mtu` IndexedDB database for offline retrieval. See [docs/external-libraries.md](docs/external-libraries.md) for the CDN snippets we use and guidance on mirroring them locally.
 
 ## Local vendor assets
 For full offline capability, copy any CDN-hosted files—such as Google Fonts, Bootstrap, Font Awesome or AOS—into a `vendor/` folder and update your HTML to reference these local copies. The service worker will then precache them alongside your own styles and scripts.

--- a/docs/external-libraries.md
+++ b/docs/external-libraries.md
@@ -1,0 +1,46 @@
+# External Libraries
+
+The MiniTools Universe pages include a few small libraries via public CDNs. Copy these files into the `vendor/` folder if you need full offline support, then update the tags below to point to your local copies.
+
+## Common CDN snippets
+
+```html
+<!-- Google Fonts -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Fira+Code&display=swap" rel="stylesheet">
+
+<!-- CSS frameworks and animations -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-TNPe8tkCbZ2M1zDh/QEqplLWYwgdEN0OZK0s8AjtKoa6HgMHtYjgJv1bLvK+cvM/" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css">
+<link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css">
+<script src="https://cdn.tailwindcss.com?plugins=daisyui"></script>
+
+<!-- UI helpers -->
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/ui@3.x.x/dist/cdn.min.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/instant.page@5.1.1/instantpage.mjs"></script>
+
+<!-- Animation and graphing -->
+<script type="module">
+  import {gsap} from 'https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/gsap.min.js';
+  import {ScrollTrigger} from 'https://cdn.jsdelivr.net/npm/gsap@3.12.2/dist/ScrollTrigger.min.js';
+  gsap.registerPlugin(ScrollTrigger);
+  window.gsap = gsap;
+  window.ScrollTrigger = ScrollTrigger;
+</script>
+<script defer src="https://cdn.jsdelivr.net/npm/function-plot@1/dist/function-plot.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6ZvzLJz2GV5/C/PObbIVdQydb9h9NP7VDaRao7IhiHBpjz2uVH54camz1Dtr1cG" crossorigin="anonymous"></script>
+<script defer src="https://unpkg.com/aos@next/dist/aos.js"></script>
+```
+
+Dexie.js is loaded as an ES module within `db.js`:
+
+```javascript
+import Dexie from 'https://cdn.jsdelivr.net/npm/dexie@3.2.5/dist/dexie.mjs';
+```
+
+## Best practice
+
+When shipping for offline use, download each CDN file once during your build and store it in `vendor/`. Update the `<link>` or `<script>` tags to point to these local paths so the service worker can precache them.


### PR DESCRIPTION
## Summary
- document CDN snippets in docs/external-libraries.md
- link the document from the Offline caching section in README
- track the new documentation task in AGENTS.md

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684eda657f4c8321a0a8e5ef776053b9