### PR TITLE
Update CDN policy docs and nav styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,14 @@
 | **OminiReq** | Dependency and tooling advice | Need for new lib/tool; recurring code patterns | Recommend libraries/dev‑tools; update `requirements.txt` (or note npm/dev deps) |
 | **OminiSEO** | Organic‑search optimisation | New page; content changes; scheduled audit | Craft meta tags & JSON‑LD; update sitemap & internal links; run SEO checks |
 | **OminiLogic** | JavaScript logic & algorithm tuning | New tool logic; bug/perf report | Optimise code; expand features; verify correctness & suggest simple tests |
+
 > **Third‑party libraries only**: CDN links are used by default, but critical assets may be copied to `vendor/` for offline availability.
+
+## CDN Usage & Vendor Policy
+To keep pages lightweight we reference frameworks like Tailwind, Alpine and GSAP
+via CDN links. When preparing an offline bundle or improving load times, download
+each CDN file into the `vendor/` directory and update the HTML to point to these
+local paths. `docs/external-libraries.md` lists the snippets to mirror.
 
 ---
 
@@ -56,9 +63,6 @@
 ## Task List
 
 ### 🔄 Active
-- [ ] Document CDN usage and vendor policy in AGENTS.md (assigned → **OminiDoc**)
-- [ ] Create docs/external-libraries.md and link it from README.md (assigned → **OminiDoc**)
-
 
 ### ✅ Completed
 - [x] Added `<link rel="manifest">` to all pages (OminiUI).
@@ -80,5 +84,6 @@
 - [x] Download `workbox-sw.js` during build and load it from `/vendor/workbox/`; update `sw.js` accordingly (assigned → **OminiReq**) (build copies local library)
 - [x] Provide PowerShell script for Windows to download OpenMoji icons into `assets/` (assigned → **OminiReq**) (script added)
 - [x] Summarize CDN usage in `docs/external-libraries.md` and link from `README.md` (assigned → **OminiDoc**) (external libs documented)
+- [x] Document CDN usage and vendor policy in AGENTS.md (assigned → **OminiDoc**) (added policy section)
 
 ---

--- a/index.html
+++ b/index.html
@@ -51,12 +51,12 @@ tailwind.config = {
       <i class="fa-solid fa-xmark" x-show="open"></i>
     </button>
     <nav :class="open?'flex':'hidden md:flex'" class="flex-col md:flex-row gap-4 absolute md:static top-full left-0 w-full bg-background md:bg-transparent p-4 md:p-0">
-      <a href="#calculators" class="hover:text-accent">Calculators</a>
-      <a href="#converters" class="hover:text-accent">Converters</a>
-      <a href="#productivity" class="hover:text-accent">Productivity</a>
-      <a href="#generators" class="hover:text-accent">Generators</a>
-      <a href="#developer" class="hover:text-accent">Developer</a>
-      <a href="#text" class="hover:text-accent">Text Tools</a>
+      <a href="#calculators" class="text-text hover:text-accent">Calculators</a>
+      <a href="#converters" class="text-text hover:text-accent">Converters</a>
+      <a href="#productivity" class="text-text hover:text-accent">Productivity</a>
+      <a href="#generators" class="text-text hover:text-accent">Generators</a>
+      <a href="#developer" class="text-text hover:text-accent">Developer</a>
+      <a href="#text" class="text-text hover:text-accent">Text Tools</a>
     </nav>
     <button @click="$store.theme.toggle()" class="text-accent text-xl focus:outline-none focus-visible:ring ml-4" aria-label="Toggle theme">
       <i x-show="$store.theme.mode==='dark'" class="fa-solid fa-sun"></i>


### PR DESCRIPTION
## Summary
- document CDN policy and vendor folder in AGENTS
- mark remaining tasks complete
- fix navigation link styling for better contrast

## Testing
- `html5validator --config .html5validator.yml index.html`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684edcd72ee08321aa2c16ed04dd0716