### PR TITLE
Run tests & add build fix task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ local paths. `docs/external-libraries.md` lists the snippets to mirror.
 
 ### 🔄 Active
 
+- [ ] Ensure `npm run build` copies `index.html` and tool pages to `dist/` so `pa11y` tests run on actual pages (assigned → **OminiUI**)
+
 ### ✅ Completed
 - [x] Mirror CDN CSS/JS in vendor/ and update HTML references (assigned → **OminiUI**) (local files added)
 - [x] Added `<link rel="manifest">` to all pages (OminiUI).


### PR DESCRIPTION
## Summary
- run repo tests
- note failing pa11y a11y check due to missing html files in `dist`
- add new task for OminiUI to copy html files to `dist`

## Testing
- `pip install -r requirements.txt`
- `npm ci`
- `npm run lint`
- `npm run build`
- `html5validator --config .html5validator.yml index.html tools/*/index.html`
- `npx http-server dist -p 8080 &`; `npx pa11y http://localhost:8080`


------
https://chatgpt.com/codex/tasks/task_e_684ee22a89248321af9a1672e377dba2