### PR TITLE
Fix pa11y build by copying HTML

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,9 +64,9 @@ local paths. `docs/external-libraries.md` lists the snippets to mirror.
 
 ### 🔄 Active
 
-- [ ] Ensure `npm run build` copies `index.html` and tool pages to `dist/` so `pa11y` tests run on actual pages (assigned → **OminiUI**)
 
 ### ✅ Completed
+- [x] Ensure `npm run build` copies `index.html` and tool pages to `dist/` so `pa11y` tests run on actual pages (assigned → **OminiUI**) (HTML copied)
 - [x] Mirror CDN CSS/JS in vendor/ and update HTML references (assigned → **OminiUI**) (local files added)
 - [x] Added `<link rel="manifest">` to all pages (OminiUI).
 - [x] *example* Create meta descriptions for the new “Base-64 Encoder” page (assigned → **OminiSEO**) (added meta description and og tags).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a simplified demo of the MiniTools Universe static website. It provides an index page, dark mode support and a sample tool.
 
 ## Build instructions
-The repository includes prebuilt `style.min.css` and `app.min.js`, so you can simply open `index.html` without any compilation. If you modify the CSS or JavaScript sources, run `node build.js` to regenerate the minified assets and refresh the service worker cache.
+The repository includes prebuilt `style.min.css` and `app.min.js`, so you can simply open `index.html` without any compilation. If you modify the CSS or JavaScript sources or need a production build, run `npm run build` to regenerate assets and copy pages into `dist/`.
 
 ## Offline caching and database
 The site uses a Workbox service worker (`sw.js`) to precache assets and keep pages available offline. Runtime caching covers fonts, scripts and images so tools load instantly on repeat visits. Recent tool results are stored with Dexie.js (`db.js`) in an `mtu` IndexedDB database for offline retrieval. See [docs/external-libraries.md](docs/external-libraries.md) for the CDN snippets we use and guidance on mirroring them locally.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input",
     "lint:html": "htmlhint \"**/*.html\"",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:html",
-    "build": "mkdir -p dist/css vendor/workbox && cp node_modules/workbox-sw/build/workbox-sw.js vendor/workbox/workbox-sw.js && npx tailwindcss -c tailwind.config.js -i src/styles/tailwind.css -o dist/css/styles.css --minify",
+    "build": "mkdir -p dist/css vendor/workbox && cp node_modules/workbox-sw/build/workbox-sw.js vendor/workbox/workbox-sw.js && npx tailwindcss -c tailwind.config.js -i src/styles/tailwind.css -o dist/css/styles.css --minify && cp index.html manifest.webmanifest robots.txt sitemap.xml style.min.css dark.min.css tools.css mini.js app.min.js db.js sw.js dist/ && cp -r tools vendor dist/",
     "start": "http-server dist -p 8080"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- copy index and tool pages into `dist/` during `npm run build`
- update docs to mention the new build command
- mark the build task as complete in AGENTS

## Testing
- `pip install -r requirements.txt`
- `npm ci`
- `npm run lint`
- `npm run build`
- `html5validator --config .html5validator.yml index.html tools/*/index.html`
- `npx http-server dist -p 8080 &`
- `npx pa11y http://localhost:8080`

------
https://chatgpt.com/codex/tasks/task_e_684ee3e6d8c8832189d0999c40028d62