### PR TITLE
Add allowed domains and doc dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,21 @@ via CDN links. When preparing an offline bundle or improving load times, downloa
 each CDN file into the `vendor/` directory and update the HTML to point to these
 local paths. `docs/external-libraries.md` lists the snippets to mirror.
 
+### Additional Allowed Domains
+The following external domains are explicitly permitted for research and
+dependency retrieval when OminiReq evaluates new tools:
+
+- `pypi.org`
+- `github.com`
+- `api.github.com`
+- `raw.githubusercontent.com`
+- `docs.python.org`
+- `cdnjs.cloudflare.com`
+- `cdn.jsdelivr.net`
+- `unpkg.com`
+- `fonts.googleapis.com`
+- `fonts.gstatic.com`
+
 ---
 
 ## Meta / Management Agents
@@ -88,5 +103,6 @@ local paths. `docs/external-libraries.md` lists the snippets to mirror.
 - [x] Provide PowerShell script for Windows to download OpenMoji icons into `assets/` (assigned → **OminiReq**) (script added)
 - [x] Summarize CDN usage in `docs/external-libraries.md` and link from `README.md` (assigned → **OminiDoc**) (external libs documented)
 - [x] Document CDN usage and vendor policy in AGENTS.md (assigned → **OminiDoc**) (added policy section)
+- [x] Expand `requirements.txt` with documentation and CLI helpers; list allowed research domains (assigned → **OminiReq**)
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,16 @@ requests==2.32.3        # works with urllib3 2.3.x
 
 # Image processing
 pillow==11.2.1
+
+# Docs & build helpers
+mkdocs==1.6.1
+jinja2==3.1.6
+markdown==3.8
+python-slugify==8.0.4
+
+# CLI & HTTP utilities
+httpx==0.28.1
+typer==0.16.0
+
+# Testing
+pytest==8.4.0


### PR DESCRIPTION
## Summary
- document allowed external domains for Omini
- add doc/CLI helper packages to requirements.txt
- log dependency update in AGENTS task list

## Testing
- `npm run lint` *(fails: 822 errors, 78 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ee8451f088321b5bb96d96b724080