### PR TITLE
Add markdown tooling for AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,23 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [MiniTools Universe — Omini Agents Specification](#minitools%E2%80%AFuniverse-%omini%E2%80%AFagents-specification)
+  - [Core Specialist Agents](#core-specialist-agents)
+  - [CDN Usage & Vendor Policy](#cdn-usage--vendor-policy)
+    - [Additional Allowed Domains](#additional-allowed-domains)
+  - [Meta / Management Agents](#meta--management-agents)
+    - [**OminiForge**  (Organic Custom Agent Creator)](#ominiforge-%C2%A0organic%E2%80%AFcustom-agent-creator)
+    - [**OminiTaskMaster**  (Task‑List Coordinator)](#ominitaskmaster-%C2%A0task%E2%80%91list-coordinator)
+  - [Spawned Agents](#spawned-agents)
+  - [Archive](#archive)
+    - [**LinkCheckAgent**](#linkcheckagent)
+  - [Task List](#task%E2%80%AFlist)
+    - [🔄 Active](#%E2%80%AFactive)
+    - [✅ Completed](#%E2%80%AFcompleted)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # MiniTools Universe — Omini Agents Specification
 
 > **Sole Source of Truth**  
@@ -104,6 +124,6 @@ dependency retrieval when OminiReq evaluates new tools:
 - [x] Summarize CDN usage in `docs/external-libraries.md` and link from `README.md` (assigned → **OminiDoc**) (external libs documented)
 - [x] Document CDN usage and vendor policy in AGENTS.md (assigned → **OminiDoc**) (added policy section)
 - [x] Expand `requirements.txt` with documentation and CLI helpers; list allowed research domains (assigned → **OminiReq**)
-- [x] Research offline search libraries to power an "Omini Search" feature (assigned → **OminiReq**) (considered Fuse.js, Lunr.js, FlexSearch)
+- [x] Add `mdformat` and `doctoc` to streamline AGENTS.md updates (assigned → **OminiReq**)
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ To fetch the OpenMoji PNGs referenced by `og:image` tags and the web manifest, r
 ## Omini agents
 This project uses a set of "Omini agents" defined in `AGENTS.md` to keep docs, UI, SEO and code in sync.
 
+### Updating AGENTS.md
+Run `npm run toc` to refresh the table of contents and `mdformat AGENTS.md` to tidy up formatting.
+
 ## Keyword table
 | Tool | Meta Title | Meta Description |
 |------|------------|-----------------|

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:html": "htmlhint \"**/*.html\"",
     "lint": "npm run lint:js && npm run lint:css && npm run lint:html",
     "build": "mkdir -p dist/css vendor/workbox && cp node_modules/workbox-sw/build/workbox-sw.js vendor/workbox/workbox-sw.js && npx tailwindcss -c tailwind.config.js -i src/styles/tailwind.css -o dist/css/styles.css --minify && cp index.html manifest.webmanifest robots.txt sitemap.xml style.min.css dark.min.css tools.css mini.js app.min.js db.js sw.js dist/ && cp -r tools vendor dist/",
-    "start": "http-server dist -p 8080"
+    "start": "http-server dist -p 8080",
+    "toc": "doctoc AGENTS.md"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
@@ -24,6 +25,7 @@
     "http-server": "^14.1.1",
     "pa11y": "^9.0.0",
     "esbuild": "^0.20.0",
-    "workbox-cli": "^7.0.0"
+    "workbox-cli": "^7.0.0",
+    "doctoc": "^2.2.1"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ mkdocs==1.6.1
 jinja2==3.1.6
 markdown==3.8
 python-slugify==8.0.4
+mdformat==0.7.22
 
 # CLI & HTTP utilities
 httpx==0.28.1


### PR DESCRIPTION
## Summary
- install `doctoc` and add a script to regenerate the AGENTS.md table of contents
- install `mdformat` for consistent markdown formatting
- document how to update `AGENTS.md`
- record the new dependencies in AGENTS.md

## Testing
- `pip install -r requirements.txt`
- `npm ci`
- `npm run lint` *(fails: 822 errors, 78 warnings)*
- `npm run build`
- `html5validator --config .html5validator.yml index.html tools/*/index.html`
- `npx http-server dist -p 8080 &` then `npx pa11y http://localhost:8080` *(64 errors)*


------
https://chatgpt.com/codex/tasks/task_e_684eeeec6be883218cf4402da0895018