### PR TITLE
Add offline CDN manager docs & update agent tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,11 @@ dependency retrieval when OminiReq evaluates new tools:
 
 ### 🔄 Active
 
-_No open tasks_
+- [ ] Document the new Offline CDN Asset Manager and its CLI usage (assigned → **OminiDoc**)
+- [ ] Review the Tkinter GUI for usability and accessibility (assigned → **OminiUI**)
+- [ ] List required Python packages for the asset manager in `requirements.txt` (assigned → **OminiReq**)
+- [ ] Check that offline bundles and meta tags remain SEO friendly (assigned → **OminiSEO**)
+- [ ] Audit hashing and ZIP logic in `offline_asset_manager.py` (assigned → **OminiLogic**)
 
 ### ✅ Completed
 - [x] Redesign `index.html` with improved layout, accessibility and modern styling (assigned → **OminiUI**) (header, hero & footer refreshed)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Images are replaced by emojis or inline SVG wherever possible to keep pages smal
 
 To fetch the OpenMoji PNGs referenced by `og:image` tags and the web manifest, run `scripts\download-openmoji.ps1` on Windows. This populates the local `assets/` directory so the site works offline.
 
+## Offline CDN Asset Manager
+For a larger offline setup you can use the Python script `offline_asset_manager.py` to mirror CDN libraries automatically. It provides both a CLI and a Tkinter GUI for downloading assets into a chosen folder. See [docs/offline-cdn-manager.md](docs/offline-cdn-manager.md) for details and usage examples.
+
 ## Omini agents
 This project uses a set of "Omini agents" defined in `AGENTS.md` to keep docs, UI, SEO and code in sync.
 

--- a/docs/offline-cdn-manager.md
+++ b/docs/offline-cdn-manager.md
@@ -1,0 +1,22 @@
+# Offline CDN Asset Manager
+
+This Python utility downloads JavaScript and CSS libraries so the site can run fully offline. It works on Windows and offers both a command line interface and a simple Tkinter GUI. Assets are saved locally and a manifest file tracks SHA-256 hashes for quick verification.
+
+## Features
+- **Offline availability** – Mirror CDN files and their dependencies (fonts, images) into a local folder.
+- **Online/offline switching** – Map CDN URLs to local copies so pages use local files when offline.
+- **Integrity checks** – Performs HEAD requests before downloading and verifies file hashes.
+- **Custom asset packs** – Accepts a JSON config to define additional libraries to fetch.
+- **ZIP packaging** – Can bundle the output directory into a single archive when finished.
+
+## Command line usage
+```
+python offline_asset_manager.py [options]
+```
+- `--config <file>` – Path to a JSON configuration file of asset definitions.
+- `--output <folder>` – Destination directory for downloaded files.
+- `--verify-only` – Check URLs and existing files without downloading.
+- `--zip-output` – Create a ZIP archive of the downloaded assets.
+- `--headless` – Run without launching the Tkinter GUI.
+
+Run the script with `-h` to see all options. When launched without arguments the GUI opens by default.


### PR DESCRIPTION
## Summary
- document the Offline CDN Asset Manager tool
- reference it in README
- assign new review tasks to agents

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684fd4f5aafc8321b62c6d40dc143a63