### PR TITLE
Fix vendor paths in tool pages

### DIFF
--- a/tools/age-calculator/index.html
+++ b/tools/age-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Find your exact age in years"/>
 <meta property="og:image" content="../../assets/age-calculator-cake.png"/>
 <link rel="canonical" href="https://example.com/tools/age-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Age Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate my age?","acceptedAnswer":{"@type":"Answer","text":"Enter your birthdate and the tool displays your age automatically."}},{"@type":"Question","name":"Is the Age Calculator free?","acceptedAnswer":{"@type":"Answer","text":"Yes, it is completely free to use."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the first load, you can use the calculator without internet."}},{"@type":"Question","name":"Is my birthdate stored?","acceptedAnswer":{"@type":"Answer","text":"No data is saved; everything runs in your browser."}},{"@type":"Question","name":"Can I calculate someone else's age?","acceptedAnswer":{"@type":"Answer","text":"Yes, just enter any valid birthdate to get the age."}}]}</script>
 </head>

--- a/tools/base64-encoder/index.html
+++ b/tools/base64-encoder/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Convert text to and from base64 instantly. Works offline with no data sent to servers."/>
 <meta property="og:image" content="../../assets/base64-encoder-keyboard.png"/>
 <link rel="canonical" href="https://example.com/tools/base64-encoder/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Base64 Encoder/Decoder","operatingSystem":"Any","applicationCategory":"Converter","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I encode text?","acceptedAnswer":{"@type":"Answer","text":"Type your text then click encode to get the base64 string."}},{"@type":"Question","name":"Can I decode a base64 string?","acceptedAnswer":{"@type":"Answer","text":"Yes, paste the base64 and click decode to see the original text."}},{"@type":"Question","name":"Is it secure?","acceptedAnswer":{"@type":"Answer","text":"Encoding is done locally so your data never leaves the page."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After first visit, the tool runs without internet."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Base64 Encoder/Decoder is free to use."}}]}</script>
 </head>

--- a/tools/basic-calculator/index.html
+++ b/tools/basic-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Quick online arithmetic"/>
 <meta property="og:image" content="../../assets/basic-calculator-emoji.png"/>
 <link rel="canonical" href="https://example.com/tools/basic-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Basic Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
 </script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I use the Basic Calculator?","acceptedAnswer":{"@type":"Answer","text":"Enter numbers and operations then press equal."}},{"@type":"Question","name":"Is this calculator free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Basic Calculator is completely free."}},{"@type":"Question","name":"Can I use it offline?","acceptedAnswer":{"@type":"Answer","text":"After first load, the page works offline."}},{"@type":"Question","name":"Does it handle negative numbers?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can perform calculations with negative numbers."}},{"@type":"Question","name":"Is my data saved?","acceptedAnswer":{"@type":"Answer","text":"No personal data is stored."}}]}

--- a/tools/bmi-calculator/index.html
+++ b/tools/bmi-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Check your body mass index"/>
 <meta property="og:image" content="../../assets/bmi-calculator-scale.png"/>
 <link rel="canonical" href="https://example.com/tools/bmi-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"BMI Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I use the BMI Calculator?","acceptedAnswer":{"@type":"Answer","text":"Enter your height and weight then press calculate to see your BMI."}},{"@type":"Question","name":"Is this calculator free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the BMI Calculator is free and works offline."}},{"@type":"Question","name":"Are my numbers saved?","acceptedAnswer":{"@type":"Answer","text":"No data is stored; everything is processed in your browser."}},{"@type":"Question","name":"What units are supported?","acceptedAnswer":{"@type":"Answer","text":"Enter weight in kilograms and height in centimeters."}},{"@type":"Question","name":"What is a healthy BMI range?","acceptedAnswer":{"@type":"Answer","text":"A BMI between 18.5 and 24.9 is generally considered healthy."}}]}</script>
 </head>

--- a/tools/bmr-calculator/index.html
+++ b/tools/bmr-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Estimate daily calorie needs"/>
 <meta property="og:image" content="../../assets/bmr-calculator-fire.png"/>
 <link rel="canonical" href="https://example.com/tools/bmr-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"BMR Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate BMR?","acceptedAnswer":{"@type":"Answer","text":"Enter your gender, weight, height and age then press calculate."}},{"@type":"Question","name":"Which formula is used?","acceptedAnswer":{"@type":"Answer","text":"This tool uses the Mifflin-St Jeor equation for accuracy."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Yes, once the page loads you can use it without internet."}},{"@type":"Question","name":"Are my numbers stored?","acceptedAnswer":{"@type":"Answer","text":"No data is saved or sent anywhere."}},{"@type":"Question","name":"Can I switch units?","acceptedAnswer":{"@type":"Answer","text":"Currently inputs are in metric units for simplicity."}}]}</script>
 </head>

--- a/tools/body-fat-calculator/index.html
+++ b/tools/body-fat-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Estimate body fat percentage"/>
 <meta property="og:image" content="../../assets/body-fat-calculator-bicep.png"/>
 <link rel="canonical" href="https://example.com/tools/body-fat-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Body Fat Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I measure body fat?","acceptedAnswer":{"@type":"Answer","text":"Enter your gender, waist, neck and height measurements. The calculator uses the US Navy formula to estimate body fat."}},{"@type":"Question","name":"Is the Body Fat Calculator free?","acceptedAnswer":{"@type":"Answer","text":"Yes, this tool is free for personal use."}},{"@type":"Question","name":"Can I use metric units?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can switch between imperial and metric units."}},{"@type":"Question","name":"Does it store my data?","acceptedAnswer":{"@type":"Answer","text":"No information is saved. Everything runs locally in your browser."}},{"@type":"Question","name":"Is it mobile friendly?","acceptedAnswer":{"@type":"Answer","text":"The layout adapts to any screen so you can check body fat on phones and tablets."}}]}</script>
 </head>

--- a/tools/car-loan-calculator/index.html
+++ b/tools/car-loan-calculator/index.html
@@ -14,9 +14,9 @@
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Car Loan Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate my loan payment?","acceptedAnswer":{"@type":"Answer","text":"Enter amount, interest rate and years, then press calculate."}},{"@type":"Question","name":"Can I use this for mortgages?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can estimate mortgage payments the same way."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded it works without internet."}},{"@type":"Question","name":"Is my data saved?","acceptedAnswer":{"@type":"Answer","text":"No inputs are stored or sent anywhere."}},{"@type":"Question","name":"Is the tool free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Car Loan Calculator is completely free."}}]}</script>
 </head>

--- a/tools/circle-area-calculator/index.html
+++ b/tools/circle-area-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Find disk size from radius or diameter"/>
 <meta property="og:image" content="../../assets/circle-area-calculator-circle.png"/>
 <link rel="canonical" href="https://example.com/tools/circle-area-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Circle Area Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate circle area?","acceptedAnswer":{"@type":"Answer","text":"Enter a radius or diameter, and the calculator shows the area using pi."}},{"@type":"Question","name":"Can I enter the diameter instead?","acceptedAnswer":{"@type":"Answer","text":"Yes, the tool accepts diameter and converts it to radius automatically."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the first visit, the calculator loads from cache without the internet."}},{"@type":"Question","name":"Is this calculator free?","acceptedAnswer":{"@type":"Answer","text":"Absolutely. You can use the Circle Area Calculator without charge or sign-up."}},{"@type":"Question","name":"Are my numbers stored?","acceptedAnswer":{"@type":"Answer","text":"No values are saved, ensuring your input remains private."}}]}</script>
 </head>

--- a/tools/color-converter/index.html
+++ b/tools/color-converter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Convert hex colors to RGB or HSL"/>
 <meta property="og:image" content="../../assets/palette.png"/>
 <link rel="canonical" href="https://example.com/tools/color-converter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Color Converter","operatingSystem":"Any","applicationCategory":"Converter","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I convert HEX to RGB?","acceptedAnswer":{"@type":"Answer","text":"Enter a HEX value and click convert to see the RGB values."}},{"@type":"Question","name":"Can it convert to HSL?","acceptedAnswer":{"@type":"Answer","text":"Yes, the HSL equivalent displays alongside the RGB output."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded the converter runs entirely in your browser."}},{"@type":"Question","name":"Is my color saved?","acceptedAnswer":{"@type":"Answer","text":"No, all conversions happen locally and no data is stored."}},{"@type":"Question","name":"Is it free to use?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Color Converter is completely free."}}]}</script>
 </head>

--- a/tools/color-picker/index.html
+++ b/tools/color-picker/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Pick colors and copy codes instantly"/>
 <meta property="og:image" content="../../assets/palette.png"/>
 <link rel="canonical" href="https://example.com/tools/color-picker/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Color Picker","operatingSystem":"Any","applicationCategory":"Design","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I copy a color code?","acceptedAnswer":{"@type":"Answer","text":"Select a color and click the copy button next to the value you need."}},{"@type":"Question","name":"What formats are shown?","acceptedAnswer":{"@type":"Answer","text":"The picker displays HEX, RGB and HSL values for each color."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Yes, once loaded the color picker functions without an internet connection."}},{"@type":"Question","name":"Is my selection stored?","acceptedAnswer":{"@type":"Answer","text":"No information is saved; everything runs locally in your browser."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"The Color Picker is completely free to use."}}]}</script>
 </head>

--- a/tools/compound-interest-calculator/index.html
+++ b/tools/compound-interest-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="See savings grow with compound interest"/>
 <meta property="og:image" content="../../assets/compound-interest-chart.png"/>
 <link rel="canonical" href="https://example.com/tools/compound-interest-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Compound Interest Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How is compound interest calculated?","acceptedAnswer":{"@type":"Answer","text":"Enter principal, rate, times per year, and years; the calculator computes total using the standard formula."}},{"@type":"Question","name":"Can I see the final balance?","acceptedAnswer":{"@type":"Answer","text":"Yes, it displays both interest earned and final balance."}},{"@type":"Question","name":"Is this tool free?","acceptedAnswer":{"@type":"Answer","text":"The calculator is free and works offline."}},{"@type":"Question","name":"Does it support monthly compounding?","acceptedAnswer":{"@type":"Answer","text":"Set compounding to 12 to calculate monthly."}},{"@type":"Question","name":"Are my inputs saved anywhere?","acceptedAnswer":{"@type":"Answer","text":"No, all data stays in your browser."}}]}</script>
 </head>

--- a/tools/countdown-timer/index.html
+++ b/tools/countdown-timer/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Set a timer and count down easily"/>
 <meta property="og:image" content="../../assets/countdown-timer-hourglass.png"/>
 <link rel="canonical" href="https://example.com/tools/countdown-timer/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Countdown Timer","operatingSystem":"Any","applicationCategory":"Utilities","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I start the timer?","acceptedAnswer":{"@type":"Answer","text":"Enter minutes and seconds and click start."}},{"@type":"Question","name":"Can I pause it?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can pause and resume as needed."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded the timer works without internet."}},{"@type":"Question","name":"Will it alert me?","acceptedAnswer":{"@type":"Answer","text":"A simple beep sounds when time runs out."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes, use the timer without any cost."}}]}</script>
 </head>

--- a/tools/csv-to-json/index.html
+++ b/tools/csv-to-json/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Convert CSV files to JSON instantly"/>
 <meta property="og:image" content="../../assets/csv-to-json-bookmark.png"/>
 <link rel="canonical" href="https://example.com/tools/csv-to-json/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"CSV to JSON Converter","operatingSystem":"Any","applicationCategory":"DeveloperTool","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>

--- a/tools/currency-converter/index.html
+++ b/tools/currency-converter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Convert between USD, EUR and GBP"/>
 <meta property="og:image" content="../../assets/currency-converter-money.png"/>
 <link rel="canonical" href="https://example.com/tools/currency-converter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Currency Converter","operatingSystem":"Any","applicationCategory":"Converter","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I convert currencies?","acceptedAnswer":{"@type":"Answer","text":"Enter an amount, choose currencies and press convert."}},{"@type":"Question","name":"Are rates live?","acceptedAnswer":{"@type":"Answer","text":"This demo uses static rates so it also works offline."}},{"@type":"Question","name":"Can I add more currencies?","acceptedAnswer":{"@type":"Answer","text":"Currently USD, EUR and GBP are included for simplicity."}},{"@type":"Question","name":"Is it free to use?","acceptedAnswer":{"@type":"Answer","text":"Yes, there are no costs or tracking involved."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Yes, conversion happens locally after the first load."}}]}</script>
 </head>

--- a/tools/date-difference-calculator/index.html
+++ b/tools/date-difference-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Measure the days between any two dates"/>
 <meta property="og:image" content="../../assets/date-diff-calendar.png"/>
 <link rel="canonical" href="https://example.com/tools/date-difference-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Date Difference Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I find days between two dates?","acceptedAnswer":{"@type":"Answer","text":"Select a start and end date to instantly see the number of days in between."}},{"@type":"Question","name":"Can I use past and future dates?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can calculate differences for any pair of dates."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded, the calculator runs completely in your browser."}},{"@type":"Question","name":"Is my date information stored?","acceptedAnswer":{"@type":"Answer","text":"No information leaves your device; everything is calculated locally."}},{"@type":"Question","name":"Is the tool free?","acceptedAnswer":{"@type":"Answer","text":"Yes, this tool is free for unlimited use."}}]}</script>
 </head>

--- a/tools/dice-roller/index.html
+++ b/tools/dice-roller/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Roll dice with animation and copy results"/>
 <meta property="og:image" content="../../assets/dice-die.png"/>
 <link rel="canonical" href="https://example.com/tools/dice-roller/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Dice Roller","operatingSystem":"Any","applicationCategory":"Game","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I roll the dice?","acceptedAnswer":{"@type":"Answer","text":"Click the roll button and the dice image will show a random value."}},{"@type":"Question","name":"Can I roll multiple dice?","acceptedAnswer":{"@type":"Answer","text":"Press roll again to simulate tossing several dice and sum the results."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Yes, once loaded the Dice Roller functions without internet."}},{"@type":"Question","name":"Is my result stored?","acceptedAnswer":{"@type":"Answer","text":"No data is stored; each roll happens purely in your browser."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"This Dice Roller is completely free to use."}}]}</script>
 </head>

--- a/tools/discount-calculator/index.html
+++ b/tools/discount-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Calculate sale prices and savings"/>
 <meta property="og:image" content="../../assets/discount-label.png"/>
 <link rel="canonical" href="https://example.com/tools/discount-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Discount Calculator","operatingSystem":"Any","applicationCategory":"FinancialApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I use the Discount Calculator?","acceptedAnswer":{"@type":"Answer","text":"Enter the original price and the discount percentage to see the final cost."}},{"@type":"Question","name":"Can I enter any percent off?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can use any whole or decimal percentage to match store discounts."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the first visit, the calculator runs entirely in your browser without a connection."}},{"@type":"Question","name":"Will it show how much I save?","acceptedAnswer":{"@type":"Answer","text":"The calculator displays both the amount saved and the new sale price."}},{"@type":"Question","name":"Is it free to use?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Discount Calculator is completely free and saves no personal data."}}]}</script>
 </head>

--- a/tools/epoch-time-converter/index.html
+++ b/tools/epoch-time-converter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Convert dates to and from Unix time"/>
 <meta property="og:image" content="../../assets/stopwatch.png"/>
 <link rel="canonical" href="https://example.com/tools/epoch-time-converter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Epoch Time Converter","operatingSystem":"Any","applicationCategory":"Converter","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I convert to Unix time?","acceptedAnswer":{"@type":"Answer","text":"Enter a date and click convert to see the Unix timestamp."}},{"@type":"Question","name":"Can I convert from a timestamp?","acceptedAnswer":{"@type":"Answer","text":"Yes, paste the timestamp and click from epoch to see the date."}},{"@type":"Question","name":"Does it require internet?","acceptedAnswer":{"@type":"Answer","text":"No, calculations run entirely in your browser after first load."}},{"@type":"Question","name":"Is my input stored?","acceptedAnswer":{"@type":"Answer","text":"Your data never leaves the page so it stays private."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Epoch Time Converter is free and offline-ready."}}]}</script>
 </head>

--- a/tools/fraction-calculator/index.html
+++ b/tools/fraction-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Solve fraction problems easily"/>
 <meta property="og:image" content="../../assets/fraction-calculator-briefcase.png"/>
 <link rel="canonical" href="https://example.com/tools/fraction-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Fraction Calculator","operatingSystem":"Any","applicationCategory":"EducationalApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I add fractions?","acceptedAnswer":{"@type":"Answer","text":"Enter the numerators and denominators, choose addition, and the result shows the simplified sum."}},{"@type":"Question","name":"Can I multiply fractions?","acceptedAnswer":{"@type":"Answer","text":"Yes, select multiply and the calculator will display the product in simplest form."}},{"@type":"Question","name":"Does it reduce fractions?","acceptedAnswer":{"@type":"Answer","text":"Results are automatically simplified to the lowest terms."}},{"@type":"Question","name":"Will it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the first visit the tool functions without internet."}},{"@type":"Question","name":"Is my input stored anywhere?","acceptedAnswer":{"@type":"Answer","text":"No data leaves your browser so your work stays private."}}]}</script>
 </head>

--- a/tools/fuel-cost-calculator/index.html
+++ b/tools/fuel-cost-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Estimate fuel expenses for road trips"/>
 <meta property="og:image" content="../../assets/fuel-cost-calculator-pump.png"/>
 <link rel="canonical" href="https://example.com/tools/fuel-cost-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Fuel Cost Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>

--- a/tools/graphing-calculator/index.html
+++ b/tools/graphing-calculator/index.html
@@ -11,16 +11,16 @@
 <meta property="og:description" content="Visualize equations in your browser"/>
 <meta property="og:image" content="../../assets/graphing-calculator-chart.png"/>
 <link rel="canonical" href="https://example.com/tools/graphing-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
-<script defer src="/../../vendor/cdn/function-plot.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/function-plot.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Graphing Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I graph a function?","acceptedAnswer":{"@type":"Answer","text":"Type an equation like x^2 in the input box and click Plot."}},{"@type":"Question","name":"Is the Graphing Calculator free?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can use this tool without any cost or signup."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded, all scripts are cached so it works offline."}},{"@type":"Question","name":"Can I plot multiple functions?","acceptedAnswer":{"@type":"Answer","text":"Yes, separate functions with commas to see several graphs."}},{"@type":"Question","name":"Is it mobile friendly?","acceptedAnswer":{"@type":"Answer","text":"The responsive layout lets you plot equations on any device."}}]}</script>
 </head>

--- a/tools/json-formatter/index.html
+++ b/tools/json-formatter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Format and validate JSON instantly"/>
 <meta property="og:image" content="../../assets/json-formatter-braces.png"/>
 <link rel="canonical" href="https://example.com/tools/json-formatter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"JSON Formatter","operatingSystem":"Any","applicationCategory":"DeveloperTool","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>

--- a/tools/loan-calculator/index.html
+++ b/tools/loan-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Estimate monthly mortgage or loan costs"/>
 <meta property="og:image" content="../../assets/loan-bank.png"/>
 <link rel="canonical" href="https://example.com/tools/loan-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Loan Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate my loan payment?","acceptedAnswer":{"@type":"Answer","text":"Enter amount, interest rate and years, then press calculate."}},{"@type":"Question","name":"Can I use this for mortgages?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can estimate mortgage payments the same way."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded it works without internet."}},{"@type":"Question","name":"Is my data saved?","acceptedAnswer":{"@type":"Answer","text":"No inputs are stored or sent anywhere."}},{"@type":"Question","name":"Is the tool free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Loan Calculator is completely free."}}]}</script>
 </head>

--- a/tools/markdown-editor/index.html
+++ b/tools/markdown-editor/index.html
@@ -11,16 +11,16 @@
 <meta property="og:description" content="Edit Markdown and see the result instantly"/>
 <meta property="og:image" content="../../assets/markdown-editor-pencil.png"/>
 <link rel="canonical" href="https://example.com/tools/markdown-editor/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
-<script defer src="/../../vendor/cdn/marked.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/marked.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Markdown Editor","operatingSystem":"Any","applicationCategory":"DeveloperTool","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I use the Markdown Editor?","acceptedAnswer":{"@type":"Answer","text":"Type Markdown on the left and the formatted HTML preview updates as you write."}},{"@type":"Question","name":"Does it save my text?","acceptedAnswer":{"@type":"Answer","text":"No, your notes stay local and disappear when you close the tab."}},{"@type":"Question","name":"Can I copy the HTML?","acceptedAnswer":{"@type":"Answer","text":"Yes, click the copy button under the preview to copy the rendered markup."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"This editor is free for personal and professional projects."}},{"@type":"Question","name":"Will it work offline?","acceptedAnswer":{"@type":"Answer","text":"After your first visit it loads from cache and works offline."}}]}</script>
 </head>

--- a/tools/paint-coverage-calculator/index.html
+++ b/tools/paint-coverage-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Estimate paint requirements for your space"/>
 <meta property="og:image" content="../../assets/palette.png"/>
 <link rel="canonical" href="https://example.com/tools/paint-coverage-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Paint Coverage Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I use the Paint Coverage Calculator?","acceptedAnswer":{"@type":"Answer","text":"Enter the wall area and coverage per gallon to find out how many gallons are needed."}},{"@type":"Question","name":"Does it account for multiple coats?","acceptedAnswer":{"@type":"Answer","text":"Yes, specify the number of coats and the total is adjusted."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Absolutely, the tool is free and works offline."}},{"@type":"Question","name":"Are my values saved?","acceptedAnswer":{"@type":"Answer","text":"No data is stored or sent anywhere."}},{"@type":"Question","name":"Can I change units?","acceptedAnswer":{"@type":"Answer","text":"The calculator uses square feet but you can convert units with the Unit Converter."}}]}</script>
 </head>

--- a/tools/percentage-calculator/index.html
+++ b/tools/percentage-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Find percent of any number"/>
 <meta property="og:image" content="../../assets/percentage-calculator-bars.png"/>
 <link rel="canonical" href="https://example.com/tools/percentage-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Percentage Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate a percentage?","acceptedAnswer":{"@type":"Answer","text":"Enter the base amount and the percentage to instantly see the calculated value."}},{"@type":"Question","name":"Can it find percentage increase?","acceptedAnswer":{"@type":"Answer","text":"Yes, input the original and new values to compute percentage change."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the first visit all resources are cached so the calculator works without internet."}},{"@type":"Question","name":"Is my data stored anywhere?","acceptedAnswer":{"@type":"Answer","text":"No, all calculations run in your browser and nothing is saved."}},{"@type":"Question","name":"Is it free to use?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Percentage Calculator is completely free with no registration."}}]}</script>
 </head>

--- a/tools/pomodoro-timer/index.html
+++ b/tools/pomodoro-timer/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Work in focused intervals"/>
 <meta property="og:image" content="../../assets/pomodoro-timer-tomato.png"/>
 <link rel="canonical" href="https://example.com/tools/pomodoro-timer/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Pomodoro Timer","operatingSystem":"Any","applicationCategory":"Productivity","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I start a Pomodoro?","acceptedAnswer":{"@type":"Answer","text":"Press start to begin a 25-minute session. After it ends, take a short break."}},{"@type":"Question","name":"Can I change the timer length?","acceptedAnswer":{"@type":"Answer","text":"Yes, adjust the work and break durations before starting."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Once loaded, the timer runs without internet."}},{"@type":"Question","name":"Will it alert me when time is up?","acceptedAnswer":{"@type":"Answer","text":"Yes, it plays a beep and shows a message when the session ends."}},{"@type":"Question","name":"Is my data saved?","acceptedAnswer":{"@type":"Answer","text":"No personal data is stored; settings remain in the browser only."}}]}</script>
 </head>

--- a/tools/random-number-generator/index.html
+++ b/tools/random-number-generator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Pick random numbers instantly"/>
 <meta property="og:image" content="../../assets/dice-die.png"/>
 <link rel="canonical" href="https://example.com/tools/random-number-generator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Random Number Generator","operatingSystem":"Any","applicationCategory":"Utility","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>

--- a/tools/scientific-calculator/index.html
+++ b/tools/scientific-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Advanced calculator for complex math"/>
 <meta property="og:image" content="../../assets/scientific-calculator-triangle.png"/>
 <link rel="canonical" href="https://example.com/tools/scientific-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Scientific Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>

--- a/tools/simple-interest-calculator/index.html
+++ b/tools/simple-interest-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Estimate loan interest fast"/>
 <meta property="og:image" content="../../assets/simple-interest-calculator-moneybag.png"/>
 <link rel="canonical" href="https://example.com/tools/simple-interest-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Simple Interest Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I calculate simple interest?","acceptedAnswer":{"@type":"Answer","text":"Enter principal, annual rate and time in years then press calculate."}},{"@type":"Question","name":"Can it handle monthly interest?","acceptedAnswer":{"@type":"Answer","text":"Enter the number of years including fractions for months, e.g. 1.5 for 18 months."}},{"@type":"Question","name":"Is this calculator free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the tool is completely free and works offline after first load."}},{"@type":"Question","name":"Does it store my numbers?","acceptedAnswer":{"@type":"Answer","text":"No personal data is saved; all calculations run in your browser."}},{"@type":"Question","name":"Can I use it on my phone?","acceptedAnswer":{"@type":"Answer","text":"The responsive design works well on mobile devices."}}]}</script>
 </head>

--- a/tools/stopwatch/index.html
+++ b/tools/stopwatch/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Simple online stopwatch"/>
 <meta property="og:image" content="../../assets/stopwatch.png"/>
 <link rel="canonical" href="https://example.com/tools/stopwatch/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Stopwatch","operatingSystem":"Any","applicationCategory":"Utilities","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I start the stopwatch?","acceptedAnswer":{"@type":"Answer","text":"Click start to begin timing, stop to pause and reset to zero."}},{"@type":"Question","name":"Can I use keyboard shortcuts?","acceptedAnswer":{"@type":"Answer","text":"Yes, press space to start or stop and r to reset."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Yes, after the first load the stopwatch works without internet."}},{"@type":"Question","name":"Is data stored anywhere?","acceptedAnswer":{"@type":"Answer","text":"No information is sent or saved."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the stopwatch is completely free to use."}}]}</script>
 </head>

--- a/tools/temperature-converter/index.html
+++ b/tools/temperature-converter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Convert between Celsius and Fahrenheit"/>
 <meta property="og:image" content="../../assets/temperature-converter-thermometer.png"/>
 <link rel="canonical" href="https://example.com/tools/temperature-converter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Temperature Converter","operatingSystem":"Any","applicationCategory":"Converter","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I convert Celsius to Fahrenheit?","acceptedAnswer":{"@type":"Answer","text":"Type a Celsius value and the Fahrenheit result appears instantly."}},{"@type":"Question","name":"Can it convert Fahrenheit to Celsius?","acceptedAnswer":{"@type":"Answer","text":"Yes, enter a Fahrenheit temperature to see the Celsius equivalent."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the first visit the tool is cached and works without internet."}},{"@type":"Question","name":"Is there any cost?","acceptedAnswer":{"@type":"Answer","text":"No, the Temperature Converter is completely free to use."}},{"@type":"Question","name":"Is my data stored?","acceptedAnswer":{"@type":"Answer","text":"No data is stored; everything happens in your browser."}}]}</script>
 </head>

--- a/tools/time-zone-converter/index.html
+++ b/tools/time-zone-converter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Compare times across time zones"/>
 <meta property="og:image" content="../../assets/time-zone-converter-clock.png"/>
 <link rel="canonical" href="https://example.com/tools/time-zone-converter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Time Zone Converter","operatingSystem":"Any","applicationCategory":"Utilities","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I convert times?","acceptedAnswer":{"@type":"Answer","text":"Select the source zone, the target zone and a time to see the converted value."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"Yes, after the first visit you can use it without internet."}},{"@type":"Question","name":"Can I search for cities?","acceptedAnswer":{"@type":"Answer","text":"Use the built-in list to pick common cities quickly."}},{"@type":"Question","name":"Is daylight saving handled?","acceptedAnswer":{"@type":"Answer","text":"Yes, the browser's time zone data automatically includes daylight changes."}},{"@type":"Question","name":"Is it free to use?","acceptedAnswer":{"@type":"Answer","text":"The tool is free and stores no personal data."}}]}</script>
 </head>

--- a/tools/tip-calculator/index.html
+++ b/tools/tip-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Calculate tips and split bills quickly"/>
 <meta property="og:image" content="../../assets/tip-calculator-money.png"/>
 <link rel="canonical" href="https://example.com/tools/tip-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Tip Calculator","operatingSystem":"Any","applicationCategory":"FinancialApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How does the Tip Calculator work?","acceptedAnswer":{"@type":"Answer","text":"Enter your bill amount, choose a tip percentage and the number of people splitting the bill. The calculator instantly shows each person's share."}},{"@type":"Question","name":"Is it suitable for group dining?","acceptedAnswer":{"@type":"Answer","text":"Yes. It divides the total including gratuity among diners so everyone pays their fair share."}},{"@type":"Question","name":"Can it handle custom tip rates?","acceptedAnswer":{"@type":"Answer","text":"Absolutely. You can enter any percentage to match local service customs or your own preference."}},{"@type":"Question","name":"Does it store my data?","acceptedAnswer":{"@type":"Answer","text":"No information is saved. Everything is calculated in your browser for privacy."}},{"@type":"Question","name":"Will it work offline?","acceptedAnswer":{"@type":"Answer","text":"After the initial load the page works without an internet connection."}}]}</script>
 </head>

--- a/tools/triangle-area-calculator/index.html
+++ b/tools/triangle-area-calculator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Compute triangle area from base and height"/>
 <meta property="og:image" content="../../assets/triangle-area-calculator-triangle.png"/>
 <link rel="canonical" href="https://example.com/tools/triangle-area-calculator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Triangle Area Calculator","operatingSystem":"Any","applicationCategory":"Calculator","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I find triangle area?","acceptedAnswer":{"@type":"Answer","text":"Enter base and height then press calculate to see the area."}},{"@type":"Question","name":"Can I use different units?","acceptedAnswer":{"@type":"Answer","text":"Yes, the result is in the same units you enter for base and height."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After your first visit, the tool runs entirely from your browser."}},{"@type":"Question","name":"Is it free?","acceptedAnswer":{"@type":"Answer","text":"Yes, the Triangle Area Calculator is completely free to use."}},{"@type":"Question","name":"Is my input saved?","acceptedAnswer":{"@type":"Answer","text":"No values are stored or sent anywhere; everything stays on your device."}}]}</script>
 </head>

--- a/tools/unit-converter/index.html
+++ b/tools/unit-converter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Quickly convert metric and imperial units"/>
 <meta property="og:image" content="../../assets/unit-converter-cycle.png"/>
 <link rel="canonical" href="https://example.com/tools/unit-converter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Unit Converter","operatingSystem":"Any","applicationCategory":"Converter","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I change units?","acceptedAnswer":{"@type":"Answer","text":"Choose the unit types from the dropdowns, enter a value, and the result updates automatically."}},{"@type":"Question","name":"Is there a cost?","acceptedAnswer":{"@type":"Answer","text":"No, the Unit Converter is completely free to use."}},{"@type":"Question","name":"Does it work offline?","acceptedAnswer":{"@type":"Answer","text":"After first load, all files are cached so it works offline."}},{"@type":"Question","name":"What units are supported?","acceptedAnswer":{"@type":"Answer","text":"It currently handles common length and weight units like meters, feet, kilograms, and pounds."}},{"@type":"Question","name":"Can I use it on mobile?","acceptedAnswer":{"@type":"Answer","text":"Yes, the layout is responsive for phones and tablets."}}]}</script>
 </head>

--- a/tools/uuid-generator/index.html
+++ b/tools/uuid-generator/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Generate version 4 UUIDs instantly"/>
 <meta property="og:image" content="../../assets/uuid-generator-id.png"/>
 <link rel="canonical" href="https://example.com/tools/uuid-generator/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"UUID Generator","operatingSystem":"Any","applicationCategory":"DeveloperTool","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>

--- a/tools/word-counter/index.html
+++ b/tools/word-counter/index.html
@@ -11,15 +11,15 @@
 <meta property="og:description" content="Free word and character counter"/>
 <meta property="og:image" content="../../assets/markdown-editor-pencil.png"/>
 <link rel="canonical" href="https://example.com/tools/word-counter/" />
-<link rel="stylesheet" href="/../../vendor/cdn/bootstrap.min.css">
-<link rel="stylesheet" href="/../../vendor/cdn/animate.min.css"/>
-<link rel="stylesheet" href="/../../vendor/cdn/aos.css"/>
+<link rel="stylesheet" href="/vendor/cdn/bootstrap.min.css">
+<link rel="stylesheet" href="/vendor/cdn/animate.min.css"/>
+<link rel="stylesheet" href="/vendor/cdn/aos.css"/>
 <link rel="stylesheet" href="../../style.min.css">
 <link rel="stylesheet" href="../../dark.min.css" id="darkCss" media="(prefers-color-scheme: dark)">
 <link rel="stylesheet" href="../../tools.css">
-<script defer src="/../../vendor/cdn/aos.js"></script>
+<script defer src="/vendor/cdn/aos.js"></script>
 <script defer src="../../app.min.js"></script>
-<script defer src="/../../vendor/cdn/bootstrap.bundle.min.js"></script>
+<script defer src="/vendor/cdn/bootstrap.bundle.min.js"></script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Word Counter","operatingSystem":"Any","applicationCategory":"TextTool","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- load vendor assets from root `/vendor` in all tool pages

## Testing
- `npm run build`
- `http-server dist -p 8080` then `curl -I` to an example page and vendor CSS

------
https://chatgpt.com/codex/tasks/task_e_684fd7e7e3ac8321837c0b19fff4984f