### PR TITLE
Add custom asset JSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Images are replaced by emojis or inline SVG wherever possible to keep pages smal
 To fetch the OpenMoji PNGs referenced by `og:image` tags and the web manifest, run `scripts\download-openmoji.ps1` on Windows. This populates the local `assets/` directory so the site works offline.
 
 ## Offline CDN Asset Manager
-For a larger offline setup you can use the Python script `offline_asset_manager.py` to mirror CDN libraries automatically. It provides both a CLI and a Tkinter GUI for downloading assets into a chosen folder. See [docs/offline-cdn-manager.md](docs/offline-cdn-manager.md) for details and usage examples.
+For a larger offline setup you can use the Python script `offline_asset_manager.py` to mirror CDN libraries automatically. It provides both a CLI and a Tkinter GUI for downloading assets into a chosen folder. See [docs/offline-cdn-manager.md](docs/offline-cdn-manager.md) for details, including a JSON example for defining custom asset URLs.
 
 ## Link checking
 After running `npm run build`, execute `npm run check-links` to scan the `dist/` folder for broken internal links. This command uses [linkinator](https://github.com/JustinBeckwith/linkinator) and skips external URLs. If you do wish to verify external links, make sure any required network proxy is configured via the `HTTP_PROXY` or `HTTPS_PROXY` environment variables.

--- a/docs/offline-cdn-manager.md
+++ b/docs/offline-cdn-manager.md
@@ -20,3 +20,18 @@ python offline_asset_manager.py [options]
 - `--headless` – Run without launching the Tkinter GUI.
 
 Run the script with `-h` to see all options. When launched without arguments the GUI opens by default.
+
+## Example config file
+You can extend the built-in catalog with your own CDN links using a JSON file.
+Create `my-assets.json` with the following structure:
+
+```json
+{
+  "assets": [
+    "https://cdn.example.com/mylib/1.0.0/mylib.min.css",
+    "https://cdn.example.com/mylib/1.0.0/mylib.min.js"
+  ]
+}
+```
+
+Then run `python offline_asset_manager.py --config my-assets.json` to download these files alongside the defaults.


### PR DESCRIPTION
## Summary
- show a sample JSON config in `docs/offline-cdn-manager.md`
- mention the example snippet in the README

## Testing
- `npm run lint`
- `python -m py_compile offline_asset_manager.py`
- `python offline_asset_manager.py --help`

------
https://chatgpt.com/codex/tasks/task_e_684feb28cb2083218b98fb0db525102b