### PR TITLE
Improve asset manager progress output

### DIFF
--- a/docs/offline-cdn-manager.md
+++ b/docs/offline-cdn-manager.md
@@ -20,3 +20,14 @@ python offline_asset_manager.py [options]
 - `--headless` – Run without launching the Tkinter GUI.
 
 Run the script with `-h` to see all options. When launched without arguments the GUI opens by default.
+
+## Example output
+
+Running without options downloads the built-in assets and shows progress bars:
+
+```
+Processing 3 assets
+⠸ bootstrap.min.css       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 232.8/? kB 245.6 MB/s
+⠸ bootstrap.bundle.min.js ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 80.7/? kB  128.4 MB/s
+⠸ jquery.min.js           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 87.5/? kB  119.4 MB/s
+```


### PR DESCRIPTION
## Summary
- show download progress with `rich.progress`
- print informative messages with `rich.console`
- document new progress bar output

## Testing
- `npm run lint` *(fails: eqeqeq and other errors)*
- `python -m py_compile offline_asset_manager.py`
- `python offline_asset_manager.py --headless | head -n 20`
- `python offline_asset_manager.py --verify-only --headless | head -n 20`
- `python offline_asset_manager.py --zip-output --headless | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_684feb411fcc8321b4471ec3772418d8