### PR TITLE
Integrate DaisyUI with new OminiTheme agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 |-------|---------|--------------|--------------------------|
 | **OminiDoc** | Project & user‑facing documentation | New/updated tool; request for docs | Keep README, guides, and keyword tables current; add usage instructions; log setup changes |
 | **OminiUI** | UI consistency, accessibility, performance | New HTML page or style tweak | Enforce shared design; refactor HTML/CSS; improve a11y & responsiveness |
+| **OminiTheme** | Tailwind/DaisyUI theme management | New design or theming request | Configure DaisyUI themes, update toggle logic and compile Tailwind styles |
 | **OminiReq** | Dependency and tooling advice | Need for new lib/tool; recurring code patterns | Recommend libraries/dev‑tools; update `requirements.txt` (or note npm/dev deps) |
 | **OminiSEO** | Organic‑search optimisation | New page; content changes; scheduled audit | Craft meta tags & JSON‑LD; update sitemap & internal links; run SEO checks |
 | **OminiLogic** | JavaScript logic & algorithm tuning | New tool logic; bug/perf report | Optimise code; expand features; verify correctness & suggest simple tests |
@@ -133,4 +134,5 @@ dependency retrieval when OminiReq evaluates new tools:
 - [x] Migrate `.eslintignore` to `eslint.config.js`, update lint script and add `"type": "module"` to `package.json` (assigned → **OminiReq**)
 
 - [x] Updated esbuild and workbox-cli to latest versions to address security warnings (assigned → **OminiReq**)
+- [x] Integrate DaisyUI plugin with Tailwind and document theme setup (assigned → **OminiTheme**) (plugin added and config updated)
 ---

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simplified demo of the MiniTools Universe static website. It provides 
 
 ## Build instructions
 The repository includes prebuilt `style.min.css` and `app.min.js`, so you can simply open `index.html` without any compilation. If you modify the CSS or JavaScript sources or need a production build, run `npm run build` to regenerate assets and copy pages into `dist/`.
-After upgrading, run `npm audit` to check for remaining advisories. This repo currently uses esbuild 0.25 and workbox-cli 7.3 to address recent security warnings.
+After upgrading, run `npm audit` to check for remaining advisories. This repo currently uses esbuild 0.25 and workbox-cli 7.3 to address recent security warnings. The build also includes the DaisyUI plugin for Tailwind, which compiles light, dark and cupcake themes automatically.
 
 ## Site search
 Run `npm install` to fetch dev dependencies, including Fuse.js. `npm run build` will create `search-index.json` from `tools.csv` and copy it with `search.js` into `dist/`. The home page loads `search.js` and `fuse.min.js` from `vendor/cdn/` so you can quickly filter tools offline using the search box.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "autoprefixer": "^10.4.21",
+        "daisyui": "^5.0.43",
         "esbuild": "^0.25.5",
         "eslint": "^9.29.0",
         "fuse.js": "^7.0.0",
@@ -4183,6 +4184,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.0.43",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.43.tgz",
+      "integrity": "sha512-2pshHJ73vetSpsbAyaOncGnNYL0mwvgseS1EWy1I9Qpw8D11OuBoDNIWrPIME4UFcq2xuff3A9x+eXbuFR9fUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
     "node_modules/data-uri-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "stylelint": "^16.15.0",
     "stylelint-config-standard": "^38.0.0",
     "tailwindcss": "^3.4.4",
-    "workbox-cli": "^7.3.0"
+    "workbox-cli": "^7.3.0",
+    "daisyui": "^5.0.43"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,8 @@
 /* eslint-env node */
-/* global module */
+import daisyui from 'daisyui';
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: [
     './src/**/*.{html,js,ts,jsx,tsx,vue,md}',
     './public/**/*.html'
@@ -9,5 +10,8 @@ module.exports = {
   theme: {
     extend: {}
   },
-  plugins: []
+  plugins: [daisyui],
+  daisyui: {
+    themes: ['light', 'dark', 'cupcake']
+  }
 }


### PR DESCRIPTION
## Summary
- add OminiTheme agent description and mark DaisyUI task as complete
- install DaisyUI and enable it in Tailwind config
- mention DaisyUI plugin in README

## Testing
- `npm run lint`
- `npm audit --omit=dev`


------
https://chatgpt.com/codex/tasks/task_e_685014af43c083218e96af414cac0dd3