### PR TITLE
Fix navigation when gsap missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,4 +135,5 @@ dependency retrieval when OminiReq evaluates new tools:
 
 - [x] Updated esbuild and workbox-cli to latest versions to address security warnings (assigned → **OminiReq**)
 - [x] Integrate DaisyUI plugin with Tailwind and document theme setup (assigned → **OminiTheme**) (plugin added and config updated)
+- [x] Allow link navigation when GSAP fails to load (assigned → **OminiLogic**) (conditional fade animation in `mini.js`)
 ---

--- a/mini.js
+++ b/mini.js
@@ -14,7 +14,13 @@ document.addEventListener('DOMContentLoaded',()=>{
     });
   }
   document.querySelectorAll('a[href$=".html"]').forEach(a=>{
-    a.addEventListener('click',e=>{if(e.ctrlKey||e.metaKey)return;e.preventDefault();gsap.to('body',{opacity:0,duration:0.4,onComplete:()=>{window.location=a.href;}});});
+    a.addEventListener('click',e=>{
+      if(e.ctrlKey||e.metaKey)return;
+      if(window.gsap){
+        e.preventDefault();
+        gsap.to('body',{opacity:0,duration:0.4,onComplete:()=>{window.location=a.href;}});
+      }
+    });
   });
   document.querySelectorAll('.tool-card').forEach(card=>{
     const arrow=card.querySelector('.fa-arrow-right');


### PR DESCRIPTION
## Summary
- allow default navigation if gsap is unavailable
- log fix in AGENTS task list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850207da920832193595f2a725def17