### PR TITLE
Improve tool page header styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,13 @@ a:focus{outline:2px dashed var(--accent); outline-offset:2px;}
 .desc {max-height:0;overflow:hidden;opacity:0;transition:max-height var(--transition),opacity var(--transition);font-size:.9rem;color:#c9d1d9;}
 .tool-card:hover .desc,.tool-card:focus .desc {max-height:40px;opacity:1;}
 
+/* Tool page header */
+.tool-header{background:var(--bg-secondary);box-shadow:0 4px 8px rgba(0,0,0,.6);position:sticky;top:0;z-index:20;}
+.tool-header .container{display:flex;align-items:center;gap:1rem;}
+.tool-header h1{margin:0;font-size:1.25rem;display:flex;align-items:center;gap:.5rem;}
+.theme-toggle{margin-left:auto;background:none;border:0;font-size:1.2rem;cursor:pointer;color:var(--accent);transition:transform .2s,color .2s;}
+.theme-toggle:hover{transform:rotate(20deg);color:#b3dfff;}
+
 /* Button */
 .copy-btn{background:var(--accent);color:#fff;border:0;border-radius:var(--radius);padding:.4rem .75rem;cursor:pointer;transition:background var(--transition),transform var(--transition);}
 .copy-btn:hover{background:#3a6fd8;}


### PR DESCRIPTION
## Summary
- style tool page headers consistently

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850263ae940832194c572c29d4da51e